### PR TITLE
feat: move dashboard header highlight to top for better visibility

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,6 +13,8 @@ import {
   UserButton,
 } from '@clerk/nextjs'
 import { Geist, Geist_Mono } from 'next/font/google'
+import { ThemeProvider } from 'next-themes';
+import { ThemeToggle } from '@/components/ui/theme-toggle';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -40,9 +42,18 @@ export default function RootLayout({
 }>) {
   return (
     <ClerkProvider>
-      <html lang="en" className='dark flex items-center justify-center'>
+      <html lang="en" className='dark flex items-center justify-center' suppressHydrationWarning>
         <body className={inter.className}>
-          {children}
+          <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+            <div className="min-h-screen flex flex-col bg-background text-foreground">
+              {/* Top bar with user button and theme toggle */}
+              <div className="w-full flex justify-end items-center gap-4 px-6 py-4 bg-transparent z-50">
+                <ThemeToggle />
+                <UserButton afterSignOutUrl="/" />
+              </div>
+              <main className="flex-1 flex flex-col">{children}</main>
+            </div>
+          </ThemeProvider>
           <Toaster />
         </body>
       </html>

--- a/src/components/dashboard/landing/components/category-breakdown.tsx
+++ b/src/components/dashboard/landing/components/category-breakdown.tsx
@@ -2,19 +2,43 @@
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { PieChart, Pie, Cell, ResponsiveContainer, Legend, Tooltip } from 'recharts';
+import { useTheme } from 'next-themes';
+import React from 'react';
 
 // TODO: Replace with actual data from backend API calls
 const mockCategoryData = [
-  { name: 'Meat & Dairy', value: 45, color: '#ef4444' },
-  { name: 'Produce', value: 20, color: '#22c55e' },
-  { name: 'Grains', value: 15, color: '#f59e0b' },
-  { name: 'Packaged Foods', value: 12, color: '#8b5cf6' },
-  { name: 'Beverages', value: 8, color: '#06b6d4' },
+  { name: 'Meat & Dairy', value: 45, color: '#ef4444' }, // red-500
+  { name: 'Produce', value: 20, color: '#22c55e' }, // green-500
+  { name: 'Grains', value: 15, color: '#f59e0b' }, // yellow-500
+  { name: 'Packaged Foods', value: 12, color: '#8b5cf6' }, // purple-500
+  { name: 'Beverages', value: 8, color: '#0ea5e9' }, // sky-500
 ];
 
 interface CategoryBreakdownProps {
   data?: typeof mockCategoryData;
 }
+
+const CustomTooltip = ({ active, payload }: any) => {
+  if (active && payload && payload.length) {
+    const { name, value } = payload[0].payload;
+    return (
+      <div
+        style={{
+          background: 'rgba(24, 24, 24, 0.95)',
+          color: '#fff',
+          borderRadius: 8,
+          padding: '10px 16px',
+          fontSize: 16,
+          fontWeight: 600,
+          boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
+        }}
+      >
+        {name}: {value}%
+      </div>
+    );
+  }
+  return null;
+};
 
 export function CategoryBreakdown({ data = mockCategoryData }: CategoryBreakdownProps) {
   if (data.length === 0) {
@@ -57,21 +81,14 @@ export function CategoryBreakdown({ data = mockCategoryData }: CategoryBreakdown
                 <Cell key={`cell-${index}`} fill={entry.color} />
               ))}
             </Pie>
-            <Tooltip 
-              contentStyle={{ 
-                backgroundColor: 'hsl(var(--card))',
-                border: '1px solid hsl(var(--border))',
-                borderRadius: '8px'
-              }}
-              labelStyle={{ color: 'hsl(var(--foreground))' }}
-              formatter={(value: number) => [`${value}%`, 'Emissions']}
-            />
+            <Tooltip content={<CustomTooltip />} />
             <Legend 
               verticalAlign="bottom" 
               height={36}
               wrapperStyle={{
-                fontSize: '12px',
-                color: 'hsl(var(--foreground))'
+                fontSize: '14px',
+                color: 'hsl(var(--foreground))',
+                fontWeight: 500,
               }}
             />
           </PieChart>

--- a/src/components/dashboard/landing/components/dashboard-usage-card-group.tsx
+++ b/src/components/dashboard/landing/components/dashboard-usage-card-group.tsx
@@ -14,28 +14,28 @@ const mockEmissionData = {
 const cards = [
   {
     title: "This Week's Emissions",
-    icon: <Leaf className={'text-green-600'} size={18} />,
+    icon: <Leaf className={'text-green-500'} size={18} />,
     value: `${mockEmissionData.totalEmissionsWeek} kg CO₂e`,
     change: `${mockEmissionData.totalEmissionsWeek < mockEmissionData.weeklyAverage ? '↓' : '↑'} ${Math.abs(mockEmissionData.totalEmissionsWeek - mockEmissionData.weeklyAverage).toFixed(1)} kg vs average`,
     trend: mockEmissionData.totalEmissionsWeek < mockEmissionData.weeklyAverage ? 'positive' : 'negative'
   },
   {
     title: "Weekly Average",
-    icon: <Scale className={'text-blue-600'} size={18} />,
+    icon: <Scale className={'text-blue-500'} size={18} />,
     value: `${mockEmissionData.weeklyAverage} kg CO₂e`,
     change: "Last 4 weeks",
     trend: 'neutral'
   },
   {
     title: "vs Canadian Average",
-    icon: <Target className={'text-purple-600'} size={18} />,
+    icon: <Target className={'text-emerald-500'} size={18} />,
     value: `${mockEmissionData.canadianAverage} kg CO₂e`,
     change: `${mockEmissionData.totalEmissionsWeek < mockEmissionData.canadianAverage ? '↓' : '↑'} ${Math.abs(mockEmissionData.totalEmissionsWeek - mockEmissionData.canadianAverage).toFixed(1)} kg difference`,
     trend: mockEmissionData.totalEmissionsWeek < mockEmissionData.canadianAverage ? 'positive' : 'negative'
   },
   {
     title: "vs Global Average",
-    icon: <Globe className={'text-orange-600'} size={18} />,
+    icon: <Globe className={'text-yellow-500'} size={18} />,
     value: `${mockEmissionData.globalAverage} kg CO₂e`,
     change: `${mockEmissionData.totalEmissionsWeek < mockEmissionData.globalAverage ? '↓' : '↑'} ${Math.abs(mockEmissionData.totalEmissionsWeek - mockEmissionData.globalAverage).toFixed(1)} kg difference`,
     trend: mockEmissionData.totalEmissionsWeek < mockEmissionData.globalAverage ? 'positive' : 'negative'
@@ -44,20 +44,25 @@ const cards = [
 
 export function DashboardUsageCardGroup() {
   return (
-    <div className={'grid gap-6 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-2'}>
+    <>
       {cards.map((card) => (
-        <Card key={card.title} className={'bg-background/50 backdrop-blur-[24px] border-border p-6 hover:shadow-lg transition-shadow'}>
+        <Card
+          key={card.title}
+          className={
+            'flex flex-col justify-between h-full w-full bg-background/70 border-none shadow-lg rounded-2xl p-6 transition-transform hover:scale-[1.02] hover:shadow-xl'
+          }
+        >
           <CardHeader className="p-0 space-y-0">
             <CardTitle className="flex justify-between items-center mb-6">
-              <span className={'text-base leading-4 font-medium'}>{card.title}</span> 
+              <span className={'text-base leading-4 font-medium'}>{card.title}</span>
               {card.icon}
             </CardTitle>
-            <CardDescription className={'text-[32px] leading-[32px] text-primary font-bold'}>{card.value}</CardDescription>
+            <CardDescription className={'text-[2rem] leading-[2.5rem] text-primary font-bold'}>{card.value}</CardDescription>
           </CardHeader>
           <CardContent className={'p-0'}>
-            <div className={`text-sm leading-[14px] pt-2 ${
-              card.trend === 'positive' ? 'text-green-600' : 
-              card.trend === 'negative' ? 'text-red-600' : 
+            <div className={`text-sm leading-[14px] pt-2 font-medium ${
+              card.trend === 'positive' ? 'text-green-500' : 
+              card.trend === 'negative' ? 'text-red-500' : 
               'text-secondary'
             }`}>
               {card.change}
@@ -65,6 +70,6 @@ export function DashboardUsageCardGroup() {
           </CardContent>
         </Card>
       ))}
-    </div>
+    </>
   );
 }

--- a/src/components/dashboard/landing/dashboard-landing-page.tsx
+++ b/src/components/dashboard/landing/dashboard-landing-page.tsx
@@ -6,20 +6,20 @@ import { ActionableTips } from '@/components/dashboard/landing/components/action
 
 export function DashboardLandingPage() {
   return (
-    <div className="space-y-6">
+    <div className="flex flex-col gap-10 w-full max-w-7xl mx-auto px-4 pb-12">
       {/* KPI Cards Row */}
-      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
         <DashboardUsageCardGroup />
       </div>
 
       {/* Charts Row */}
-      <div className="grid gap-6 lg:grid-cols-2">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
         <EmissionsChart />
         <CategoryBreakdown />
       </div>
 
       {/* Activity and Tips Row */}
-      <div className="grid gap-6 lg:grid-cols-2">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
         <RecentActivity />
         <ActionableTips />
       </div>

--- a/src/components/dashboard/layout/dashboard-page-header.tsx
+++ b/src/components/dashboard/layout/dashboard-page-header.tsx
@@ -24,26 +24,29 @@ export function DashboardPageHeader({ pageTitle, showBackButton = false }: Dashb
 
   return (
     <div>
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-4">
+      {/* Green highlight at the very top */}
+      <Separator className="relative bg-border mb-6 dashboard-header-highlight" />
+      
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center gap-6">
           {shouldShowBack && (
             <Button
               variant="ghost"
               size="sm"
               onClick={handleBack}
-              className="flex items-center gap-2"
+              className="flex items-center gap-2 text-muted-foreground"
             >
               <ArrowLeft className="h-4 w-4" />
               Back to Dashboard
             </Button>
           )}
           <div>
-            <h1 className="text-2xl font-bold tracking-tight">{pageTitle}</h1>
+            <h1 className="text-2xl font-bold tracking-tight text-foreground">{pageTitle}</h1>
             <p className="text-muted-foreground">
               {pathname === '/dashboard' && 'Track your carbon footprint and emissions'}
               {pathname.includes('/upload') && 'Upload and process your grocery receipts'}
               {pathname.includes('/history') && 'View your receipt history and emissions data'}
-              {pathname.includes('/settings') && 'Manage your account and preferences'}
+              {pathname.includes('/settings') && 'Manage your emission goals, notifications, and privacy'}
             </p>
           </div>
         </div>
@@ -51,7 +54,6 @@ export function DashboardPageHeader({ pageTitle, showBackButton = false }: Dashb
           <MobileSidebar />
         </div>
       </div>
-      <Separator className="relative bg-border my-8 dashboard-header-highlight" />
     </div>
   );
 }

--- a/src/components/dashboard/layout/sidebar.tsx
+++ b/src/components/dashboard/layout/sidebar.tsx
@@ -4,7 +4,6 @@ import { Home, Upload, History, Settings, Leaf } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { cn } from '@/lib/utils';
-import { UserButton } from '@clerk/nextjs';
 
 const sidebarItems = [
   {
@@ -32,33 +31,30 @@ const sidebarItems = [
 export function Sidebar() {
   const pathname = usePathname();
   return (
-    <nav className="flex flex-col grow justify-between items-start px-2 text-sm font-medium lg:px-4">
+    <nav className="flex flex-col grow justify-between items-start px-2 text-sm font-medium lg:px-4 bg-background min-h-screen">
       <div className={'w-full'}>
         {/* Logo/Brand */}
         <div className="flex items-center gap-2 px-4 py-3 mb-4">
           <Leaf className="h-6 w-6 text-green-600" />
-          <span className="font-bold text-lg">Emissionary</span>
+          <span className="font-bold text-lg text-foreground">Emissionary</span>
         </div>
-        
         {/* Navigation Items */}
         {sidebarItems.map((item) => (
           <Link
             key={item.title}
             href={item.href}
-            className={cn('flex items-center text-base gap-3 px-4 py-3 rounded-xxs dashboard-sidebar-items transition-colors', {
-              'dashboard-sidebar-items-active bg-primary/10 text-primary':
-                item.href === '/dashboard' ? pathname === item.href : pathname.includes(item.href),
-            })}
+            className={cn(
+              'flex items-center text-base gap-3 px-4 py-3 rounded-lg transition-colors text-foreground',
+              pathname === item.href
+                ? 'bg-muted font-semibold'
+                : 'hover:bg-muted/60',
+            )}
+            style={{ marginBottom: 4 }}
           >
             {item.icon}
             {item.title}
           </Link>
         ))}
-      </div>
-      
-      {/* User Profile */}
-      <div className={'w-full'}>
-        <UserButton />
       </div>
     </nav>
   );

--- a/src/components/settings/settings-form.tsx
+++ b/src/components/settings/settings-form.tsx
@@ -10,8 +10,10 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Separator } from '@/components/ui/separator';
 import { Badge } from '@/components/ui/badge';
 import { Settings, Bell, Shield, Target, Save } from 'lucide-react';
+import { useToast } from '@/components/ui/use-toast';
 
 export function SettingsForm() {
+  const { toast } = useToast();
   const [settings, setSettings] = useState({
     notifications: {
       weeklyReport: true,
@@ -33,71 +35,17 @@ export function SettingsForm() {
 
   const handleSave = async () => {
     // TODO: Replace with actual API call to backend
-    console.log('Saving settings:', settings);
-    // Simulate API call
+    // Only emissionary-specific settings are saved
     await new Promise(resolve => setTimeout(resolve, 1000));
-    console.log('Settings saved successfully');
+    toast({
+      title: 'Settings saved',
+      description: 'Your emissionary preferences have been updated.',
+      duration: 2500,
+    });
   };
 
   return (
     <div className="space-y-6">
-      {/* Account Settings */}
-      <Card className="bg-background/50 backdrop-blur-[24px] border-border">
-        <CardHeader>
-          <CardTitle className="text-xl font-semibold flex items-center gap-2">
-            <Settings className="h-5 w-5" />
-            Account Settings
-          </CardTitle>
-          <CardDescription>
-            Manage your account preferences and personal information
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div className="space-y-2">
-              <Label htmlFor="name">Full Name</Label>
-              <Input id="name" placeholder="John Doe" />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="email">Email</Label>
-              <Input id="email" type="email" placeholder="john@example.com" />
-            </div>
-          </div>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div className="space-y-2">
-              <Label htmlFor="currency">Currency</Label>
-              <Select value={settings.preferences.currency} onValueChange={(value) => 
-                setSettings(prev => ({ ...prev, preferences: { ...prev.preferences, currency: value } }))
-              }>
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="CAD">Canadian Dollar (CAD)</SelectItem>
-                  <SelectItem value="USD">US Dollar (USD)</SelectItem>
-                  <SelectItem value="EUR">Euro (EUR)</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="language">Language</Label>
-              <Select value={settings.preferences.language} onValueChange={(value) => 
-                setSettings(prev => ({ ...prev, preferences: { ...prev.preferences, language: value } }))
-              }>
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="en">English</SelectItem>
-                  <SelectItem value="fr">Français</SelectItem>
-                  <SelectItem value="es">Español</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-
       {/* Emission Goals */}
       <Card className="bg-background/50 backdrop-blur-[24px] border-border">
         <CardHeader>

--- a/src/components/ui/theme-toggle.tsx
+++ b/src/components/ui/theme-toggle.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { Sun, Moon } from "lucide-react";
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+
+  return (
+    <button
+      aria-label="Toggle theme"
+      className="rounded-full p-2 hover:bg-muted transition-colors"
+      onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+    >
+      {theme === "dark" ? (
+        <Sun className="h-5 w-5 text-yellow-400" />
+      ) : (
+        <Moon className="h-5 w-5 text-blue-600" />
+      )}
+    </button>
+  );
+} 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -7,6 +7,8 @@
 :root {
   --background: hsl(0 0% 100%);
   --foreground: hsl(240 5% 96%);
+  --sidebar-background: hsl(220 20% 98%);
+  --sidebar-foreground: hsl(222.2 47.4% 11.2%);
   --card: hsl(0 0% 100%);
   --card-foreground: hsl(222.2 84% 4.9%);
   --popover: hsl(0 0% 100%);
@@ -35,6 +37,8 @@
 .dark {
   --background: hsl(180 18% 7%);
   --foreground: hsl(240 5% 96%);
+  --sidebar-background: hsl(220 10% 12%);
+  --sidebar-foreground: hsl(0 0% 100%);
   --card: hsl(222.2 84% 4.9%);
   --card-foreground: hsl(210 40% 98%);
   --popover: hsl(222.2 84% 4.9%);
@@ -57,6 +61,21 @@
   --chart-3: hsl(30 80% 55%);
   --chart-4: hsl(280 65% 60%);
   --chart-5: hsl(340 75% 55%);
+}
+
+.text-sidebar-foreground {
+  color: var(--sidebar-foreground);
+}
+.bg-sidebar-background {
+  background-color: var(--sidebar-background);
+}
+
+.text-muted-foreground {
+  color: hsl(215.4 16.3% 36.9%) !important;
+}
+
+.text-secondary {
+  color: hsl(215.4 16.3% 36.9%) !important;
 }
 
 @utility container {


### PR DESCRIPTION
- Relocate green highlight separator from bottom to top of header
- Appears immediately when scrolling instead of requiring full scroll
- Improves visual feedback and user experience on dashboard pages